### PR TITLE
feat: 운전면허증 등록 API 추가

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,7 @@ DB_LOGGING=true
 # auth.config
 AUTH_TOKEN_PASSWORD=RentVehicle123!@
 AUTH_TOKEN_EXPIRES_IN=90 days
+
+# aes-encrypt.config
+AES_ENCRYPT_ALGORITHM=aes-256-cbc
+AES_ENCRYPT_KEY=abcd12344321dcbaabcd12344321dcba

--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,6 +3505,11 @@
         "whatwg-url": "^7.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bcrypt": "^5.0.0",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
+    "date-fns": "^2.24.0",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { LicenseModule } from './modules/license/license.module';
 import { Module } from '@nestjs/common';
 import { join } from 'path';
 import { ConfigModule } from '@nestjs/config';
@@ -19,6 +20,7 @@ import configuration, { validate } from './config';
     DatabaseModule,
     AccountModule,
     AuthModule,
+    LicenseModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/dto/res/default-response.res.ts
+++ b/src/common/dto/res/default-response.res.ts
@@ -1,0 +1,3 @@
+export class DefaultResponseRes {
+  msg: string;
+}

--- a/src/config/configuration.config.ts
+++ b/src/config/configuration.config.ts
@@ -26,4 +26,8 @@ export default () => ({
       expiresIn: process.env.AUTH_TOKEN_EXPIRES_IN || '90 days',
     },
   },
+  'aes-encrypt': {
+    algorithm: process.env.AES_ENCRYPT_ALGORITHM || 'aes-256-cbc',
+    key: process.env.AES_ENCRYPT_KEY,
+  },
 });

--- a/src/config/configuration.validate.ts
+++ b/src/config/configuration.validate.ts
@@ -33,6 +33,9 @@ class EnvironmentVariables {
 
   @IsOptional()
   AUTH_TOKEN_EXPIRES_IN: string;
+
+  @IsNotEmpty({ message: 'aes-encrypt key 설정 필요' })
+  AES_ENCRYPT_KEY: string;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/src/core/utils/aes-encrypt/aes-encrypt-util.ts
+++ b/src/core/utils/aes-encrypt/aes-encrypt-util.ts
@@ -1,0 +1,33 @@
+import * as crypto from 'crypto';
+
+export class AesEncryptUtil {
+  // FIXME: process.env.AES_ENCRYPT_KEY를 불러오기 전에 static 변수가 할당되기 때문에 문제가 생김.
+  // 현재는 인스턴스를 생성하지만 추후에 다른 방법을 찾도록 한다.
+  constructor(
+    private readonly algorithm: string,
+    private readonly key: string,
+  ) {
+    if (this.algorithm === 'aes-256-cbc' && this.key.length !== 32) {
+      throw new Error('AES 암호화 오류: key length 에러');
+    }
+    if (this.algorithm === 'aes-128-cbc' && this.key.length !== 16) {
+      throw new Error('AES 암호화 오류: key length 에러');
+    }
+  }
+
+  public generateIv(): string {
+    return crypto.randomBytes(this.key.length / 4).toString('hex');
+  }
+
+  public encode(data: string, iv: string): string {
+    const cipher = crypto.createCipheriv(this.algorithm, this.key, iv);
+    return cipher.update(data, 'utf8', 'base64') + cipher.final('base64');
+  }
+
+  public decode(encryptedData: string, iv: string): string {
+    const decipher = crypto.createDecipheriv(this.algorithm, this.key, iv);
+    return (
+      decipher.update(encryptedData, 'base64', 'utf8') + decipher.final('utf8')
+    );
+  }
+}

--- a/src/infra/database/migrations/1633254680975-CreateLicense.ts
+++ b/src/infra/database/migrations/1633254680975-CreateLicense.ts
@@ -8,6 +8,7 @@ export class CreateLicense1633254680975 implements MigrationInterface {
       "name" varchar NOT NULL,
       "birth" date NOT NULL,
       "serial_number" varchar NOT NULL,
+      "expired_datetime" date NOT NULL,
       CONSTRAINT "pk_t_license_user_id" PRIMARY KEY (user_id),
       CONSTRAINT "uk_t_license_number" UNIQUE ("number"),
       CONSTRAINT "fk_t_license_t_user"

--- a/src/infra/database/migrations/1633254680975-CreateLicense.ts
+++ b/src/infra/database/migrations/1633254680975-CreateLicense.ts
@@ -9,6 +9,7 @@ export class CreateLicense1633254680975 implements MigrationInterface {
       "birth" date NOT NULL,
       "serial_number" varchar NOT NULL,
       "expired_datetime" date NOT NULL,
+      "iv" varchar NOT NULL,
       CONSTRAINT "pk_t_license_user_id" PRIMARY KEY (user_id),
       CONSTRAINT "uk_t_license_number" UNIQUE ("number"),
       CONSTRAINT "fk_t_license_t_user"

--- a/src/modules/license/api/license.v0.controller.ts
+++ b/src/modules/license/api/license.v0.controller.ts
@@ -1,9 +1,33 @@
-import { Controller } from '@nestjs/common';
+import { DefaultResponseRes } from './../../../common/dto/res/default-response.res';
+import { AuthGuard } from '@nestjs/passport';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { RegisterLicenseReq } from './../dto/req/register-license.req';
+import { Account } from './../../account/domain/account.entity';
 import { RegisterLicenseService } from './../application/register-license.service';
+import { UserDecorator } from './../../../common/decorators/user.decorator';
 
 @Controller('/v0/license')
 export class LicenseV0Controller {
   constructor(
     private readonly registerLicenseService: RegisterLicenseService,
   ) {}
+
+  /**
+   * @param {RegisterLicenseReq} dto
+   * @param {Account} account
+   * @returns {Promise<DefaultResponseRes>}
+   * @memberof LicenseV0Controller
+   * @description 사용자 계정의 운전면허증을 등록하는 API.
+   */
+  @UseGuards(AuthGuard('jwt'))
+  @Post('')
+  public async registerLicense(
+    @Body() dto: RegisterLicenseReq,
+    @UserDecorator() account: Account,
+  ): Promise<DefaultResponseRes> {
+    await this.registerLicenseService.register(dto, account);
+    return {
+      msg: '면허증 등록 완료.',
+    };
+  }
 }

--- a/src/modules/license/application/register-license.service.ts
+++ b/src/modules/license/application/register-license.service.ts
@@ -39,6 +39,15 @@ export class RegisterLicenseService {
     // 운전 면허증 진위 여부 검증
     await this.validateLicenseService.validate(license);
 
-    return this.licenseRepository.save(license);
+    try {
+      const savedLicense = await this.licenseRepository.save(license);
+      return savedLicense;
+    } catch (err) {
+      if (err.code && err.code === '23505') {
+        // DISCUSS: 엔티티가 이미 있으니 경고 메세지만?
+      } else {
+        throw err;
+      }
+    }
   }
 }

--- a/src/modules/license/application/register-license.service.ts
+++ b/src/modules/license/application/register-license.service.ts
@@ -1,4 +1,44 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { License } from './../domain/license.entity';
+import { LicenseRepository } from './../domain/license.repository';
+import { DbLicenseRepository } from './../infrastructure/db-license.repository';
+import { LicenseBuilder } from './../domain/license.domain.builder';
+import { ValidateLicenseService } from './../domain/validate-license.service';
+import { Account } from './../../account/domain/account.entity';
+import { RegisterLicenseReq } from './../dto/req/register-license.req';
 
 @Injectable()
-export class RegisterLicenseService {}
+export class RegisterLicenseService {
+  constructor(
+    private readonly validateLicenseService: ValidateLicenseService,
+    @Inject(DbLicenseRepository)
+    private readonly licenseRepository: LicenseRepository,
+  ) {}
+
+  /**
+   * @param {RegisterLicenseReq} dto
+   * @param {Account} account
+   * @returns {Promise<License>}
+   * @memberof RegisterLicenseService
+   * @description account 계정의 운전 면허증을 등록하는 서비스.
+   *              등록 전 면허증을 검증하는 단계를 거침.
+   */
+  public async register(
+    dto: RegisterLicenseReq,
+    account: Account,
+  ): Promise<License> {
+    const license = await new LicenseBuilder()
+      .setNumber(dto.number)
+      .setName(dto.name)
+      .setBirth(dto.birth, 'yymmdd')
+      .setSerialNumber(dto.serialNumber)
+      .setUserId(account.getId())
+      .setExpiredDate(new Date(dto.expiredAt))
+      .build();
+
+    // 운전 면허증 진위 여부 검증
+    await this.validateLicenseService.validate(license);
+
+    return this.licenseRepository.save(license);
+  }
+}

--- a/src/modules/license/domain/license-number.vo.ts
+++ b/src/modules/license/domain/license-number.vo.ts
@@ -10,7 +10,6 @@ export class LicenseNumber {
   @Column({ unique: true })
   public number: string;
 
-  // DISCUSS: number랑 합쳐서 VO로 만들지 고민.
   public num1: string;
 
   public num2: string;
@@ -26,5 +25,9 @@ export class LicenseNumber {
     this.num2 = numberSplit[1];
     this.num3 = numberSplit[2];
     this.num4 = numberSplit[3];
+  }
+
+  public validateNumber() {
+    // TODO: 면허증 번호 형식 검증.
   }
 }

--- a/src/modules/license/domain/license.domain.builder.ts
+++ b/src/modules/license/domain/license.domain.builder.ts
@@ -2,6 +2,7 @@ import { LicenseNumber } from './license-number.vo';
 import { BadRequestException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { License } from './license.entity';
+import { parse } from 'date-fns';
 
 export class LicenseBuilder {
   public number: LicenseNumber;
@@ -14,24 +15,42 @@ export class LicenseBuilder {
 
   public userId: number;
 
+  public expiredAt: Date;
+
   public setNumber(lincenseNumber: string) {
     this.number = new LicenseNumber(lincenseNumber);
+    return this;
   }
 
   public setName(userName: string) {
     this.name = userName;
+    return this;
   }
 
-  public setBirth(userBirth: Date) {
-    this.birth = userBirth;
+  public setBirth(userBirth: Date);
+  public setBirth(userBirth: string, format: string);
+  public setBirth(userBirth: Date | string, format?: string) {
+    if (typeof userBirth === 'string') {
+      this.birth = parse(userBirth, format, new Date());
+    } else {
+      this.birth = userBirth;
+    }
+    return this;
   }
 
   public setSerialNumber(serialNumber: string) {
     this.serialNumber = serialNumber;
+    return this;
+  }
+
+  public setExpiredDate(expiredAt: Date) {
+    this.expiredAt = expiredAt;
+    return this;
   }
 
   public setUserId(userId: number) {
     this.userId = userId;
+    return this;
   }
 
   public async build() {

--- a/src/modules/license/domain/license.entity.ts
+++ b/src/modules/license/domain/license.entity.ts
@@ -1,9 +1,9 @@
 import { ConflictException } from '@nestjs/common';
+import { isAfter } from 'date-fns';
 import { LicenseNumber } from './license-number.vo';
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 import { LicenseBuilder } from './license.domain.builder';
 import { Account } from './../../account/domain/account.entity';
-import { isAfter } from 'date-fns';
 
 @Entity('t_license')
 export class License {
@@ -52,7 +52,6 @@ export class License {
 
   public isExpired(): boolean {
     const now = new Date();
-    console.log(isAfter(this.expiredAt, now));
     if (isAfter(this.expiredAt, now)) {
       return false;
     }

--- a/src/modules/license/domain/validate-license.service.ts
+++ b/src/modules/license/domain/validate-license.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { License } from './license.entity';
+
+@Injectable()
+export class ValidateLicenseService {
+  /**
+   * @param {License} license
+   * @returns {Promise<void>}
+   * @memberof ValidateLicenseService
+   * @description 운전 면허증 진위 여부 검증 서비스.
+   *              면허증에 문제가 없는 경우 return;
+   */
+  public async validate(license: License): Promise<void> {
+    license.validate();
+
+    // TODO: 경찰청 운전면허증 인증 API.
+  }
+}

--- a/src/modules/license/dto/req/index.ts
+++ b/src/modules/license/dto/req/index.ts
@@ -1,0 +1,1 @@
+export { RegisterLicenseReq } from './register-license.req';

--- a/src/modules/license/dto/req/register-license.req.ts
+++ b/src/modules/license/dto/req/register-license.req.ts
@@ -1,0 +1,30 @@
+import { Matches, IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class RegisterLicenseReq {
+  @Matches(/\d{2}-\d{2}-\d{6}-\d{2}/, {
+    message: '면허증 번호 형식이 아닙니다.',
+  })
+  @IsNotEmpty({ message: '면허증 번호를 입력하세요.' })
+  public number: string;
+
+  @IsString({ message: '이름을 입력하세요.' })
+  @IsNotEmpty({ message: '이름을 입력하세요.' })
+  public name: string;
+
+  @Matches(/([0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[1,2][0-9]|3[0,1]))/, {
+    message: '생년월일 형식이 아닙니다.',
+  })
+  @IsNotEmpty({ message: '생년월일을 입력하세요.' })
+  public birth: string;
+
+  @Length(6, 6, { message: '면허증 일련번호 형식이 아닙니다.' })
+  @IsString({ message: '면허증 일련번호 형식이 아닙니다.' })
+  @IsNotEmpty({ message: '면허증 일련번호를 입력하세요.' })
+  public serialNumber: string;
+
+  @Matches(/^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/, {
+    message: '만료일 날짜 형식이 아닙니다.',
+  })
+  @IsNotEmpty({ message: '만료일 날짜를 입력하세요.' })
+  public expiredAt: string;
+}

--- a/src/modules/license/license.module.ts
+++ b/src/modules/license/license.module.ts
@@ -1,12 +1,14 @@
+import { ValidateLicenseService } from './domain/validate-license.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { LicenseV0Controller } from './api/license.v0.controller';
 import { RegisterLicenseService } from './application/register-license.service';
+import { DbLicenseRepository } from './infrastructure/db-license.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([])],
+  imports: [TypeOrmModule.forFeature([DbLicenseRepository])],
   controllers: [LicenseV0Controller],
-  providers: [RegisterLicenseService],
+  providers: [RegisterLicenseService, ValidateLicenseService],
   exports: [TypeOrmModule],
 })
-export class AccountModule {}
+export class LicenseModule {}


### PR DESCRIPTION
사용자가 차량을 렌트하기 전에 운전면허를 등록할 수 있는 API를 추가했습니다.
면허증은 번호, 이름, 생년월일, 일련번호, 만료기한 및 사용자 id를 저장하며 
면허증 번호는 AES-256-CBC를 이용해 대칭키 암호화를 진행합니다.
또한 암호화에 사용하는 iv도 저장합니다.

운전면허증에 대한 간단한 validation은 진행하며(만료기한 확인)
경찰청에 운전면허증을 검증하는 API는 추후에 구현하도록 하겠습니다. (허가 나지 않음)